### PR TITLE
Add object oriented version of F# huffman tree encoding

### DIFF
--- a/benchmarks/huffman_coding/oop_f#/Program.fs
+++ b/benchmarks/huffman_coding/oop_f#/Program.fs
@@ -12,10 +12,10 @@ type IHuffmanTree(id, freq) =
     interface IComparable<IHuffmanTree> with
         override this.CompareTo obj = 
             let res = this.Frequency - obj.Frequency
-            if res = 0 then this.Id.CompareTo(obj.Id) else res
+            if res = 0 then this.Id.CompareTo obj.Id else res
 
 
-type HuffmanLeaf(c, id, freq) =
+type HuffmanLeaf(c, freq, id) =
     inherit IHuffmanTree(id, freq)
     member val Character = c with get
 

--- a/benchmarks/huffman_coding/oop_f#/Program.fs
+++ b/benchmarks/huffman_coding/oop_f#/Program.fs
@@ -1,0 +1,85 @@
+﻿// Learn more about F# at http://fsharp.org
+
+open System
+open System.IO
+open System.Text
+open System.Collections.Generic
+
+[<AbstractClass>]
+type IHuffmanTree(id, freq) =
+    member val Id: int32 = id with get, set
+    member val Frequency: int32 = freq with get
+    interface IComparable<IHuffmanTree> with
+        override this.CompareTo obj = 
+            let res = this.Frequency - obj.Frequency
+            if res = 0 then this.Id.CompareTo(obj.Id) else res
+
+
+type HuffmanLeaf(c, id, freq) =
+    inherit IHuffmanTree(id, freq)
+    member val Character = c with get
+
+
+type HuffmanNode(left: IHuffmanTree, right: IHuffmanTree, id) =
+    inherit IHuffmanTree(id, left.Frequency + right.Frequency)
+    member val Left = left with get
+    member val Right = right with get
+
+
+type Huffman(stringToEncode) as this =
+    let mutable symbolTable = new Dictionary<char, string>()
+    do
+        let mutable frequencies = new Dictionary<char, int>()
+        for ch in stringToEncode do
+            if frequencies.ContainsKey(ch)
+            then frequencies.[ch] <- frequencies.[ch] + 1
+            else frequencies.Add(ch, 1)
+
+        let tree = this.BuildTree frequencies
+        this.UpdateSymbolTable tree (StringBuilder())
+
+    member __.BuildTree frequencies =
+        let trees = new SortedSet<IHuffmanTree>()
+        let mutable id = 0
+        for symbol: KeyValuePair<char, int> in frequencies do
+            trees.Add(HuffmanLeaf(symbol.Key, symbol.Value, id)) |> ignore
+            id <- id + 1
+
+        while trees.Count > 1 do
+            let leftChild = trees.Min
+            trees.Remove(trees.Min) |> ignore
+            let rightChild = trees.Min
+            trees.Remove(trees.Min) |> ignore
+            trees.Add(HuffmanNode(leftChild, rightChild, id)) |> ignore
+            id <- id + 1
+        trees.Min
+    
+    member this.UpdateSymbolTable tree prefix =
+        if tree :? HuffmanLeaf
+        then 
+            let leaf = tree :?> HuffmanLeaf
+            symbolTable.[leaf.Character] <- prefix.ToString()
+        else
+            let node = tree :?> HuffmanNode
+            prefix.Append("0") |> ignore
+            this.UpdateSymbolTable node.Left prefix
+            prefix.Remove(prefix.Length - 1, 1) |> ignore
+
+            prefix.Append("1") |> ignore
+            this.UpdateSymbolTable node.Right prefix
+            prefix.Remove(prefix.Length - 1, 1) |> ignore
+
+    member __.Encode stringToEncode =
+        let encodedString = StringBuilder()
+        for ch in stringToEncode do
+            encodedString.Append(symbolTable.[ch]) |> ignore
+        encodedString.ToString()
+    
+
+[<EntryPoint>]
+let main argv =
+    let testString = File.ReadAllText("benchmarks/huffman_coding/lines.txt")
+    let huffman = Huffman(testString)
+    let encodedString = huffman.Encode testString
+    printfn "The length is: %d" encodedString.Length
+    0 // return an integer exit code

--- a/benchmarks/huffman_coding/oop_f#/oop_f#.fsproj
+++ b/benchmarks/huffman_coding/oop_f#/oop_f#.fsproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>oop_f_</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Adds the object oriented version of the huffman tree encoding algorithm
Note, that the result of this algorithm is a bit more than twice the one of OOP C#,
I do not know the exact cause - This may have to be investigated (See table below)

| Program | Length |
| --------- | ------- |
| OOP C#  | 3347111 |
| OOP F#  |  6928529 |